### PR TITLE
Run Truffle Test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@ jobs:
   build:
     docker:
       - image: circleci/node:10.15
+      - image: trufflesuite/ganache-cli
+        command: ganache-cli
 
     working_directory: ~/repo
 
@@ -27,6 +29,6 @@ jobs:
 
 workflows:
   version: 2
-  run-jobs:
+  run-integration:
     jobs:
       - build

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -44,7 +44,7 @@ module.exports = {
     //
     development: {
       host: "127.0.0.1",     // Localhost (default: none)
-      port: 7545,            // Standard Ethereum port (default: none)
+      port: 8545,            // Standard Ethereum port (default: none)
       network_id: "*",       // Any network (default: none)
     },
 


### PR DESCRIPTION
The circleci and truffle config needed to be updated to correctly run the tests

The circle config now runs ganache-cli to run truffle test

Related: 41-setup-integration-pipeline